### PR TITLE
Fix for icon not matching outlet state.

### DIFF
--- a/custom_components/kohler/binary_sensor.py
+++ b/custom_components/kohler/binary_sensor.py
@@ -77,7 +77,7 @@ class KohlerBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def icon(self):
         """Get the icon to use in the front end."""
-        if self._sensor.state:
+        if self.is_on:
             return self._sensor.iconOn
 
         return self._sensor.iconOff


### PR DESCRIPTION
Previous fix for the outlet status didn't correctly update the open/close icons.