### PR TITLE
Add DHCP autodiscovery for Kohler controllers

### DIFF
--- a/custom_components/kohler/__init__.py
+++ b/custom_components/kohler/__init__.py
@@ -102,7 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if normalized_mac is not None:
         dr.async_get(hass).async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, coordinator.macAddress())},
+            identifiers={(DOMAIN, normalized_mac)},
             connections={(CONNECTION_NETWORK_MAC, normalized_mac)},
             manufacturer=MANUFACTURER,
             configuration_url=f"http://{host}",

--- a/custom_components/kohler/__init__.py
+++ b/custom_components/kohler/__init__.py
@@ -8,14 +8,23 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers import entity_registry as er
 
 from kohler import Kohler
 
-from .const import CONF_ACCEPT_LIABILITY_TERMS, DATA_KOHLER, DOMAIN
+from .const import (
+    CONF_ACCEPT_LIABILITY_TERMS,
+    DATA_KOHLER,
+    DEFAULT_NAME,
+    DOMAIN,
+    MANUFACTURER,
+    MODEL,
+)
 from .coordinator import KohlerDataUpdateCoordinator
-from .entity_helpers import build_outlet_descriptors
+from .entity_helpers import build_outlet_descriptors, normalize_mac_address
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,6 +98,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DATA_KOHLER] = coordinator
 
+    normalized_mac = normalize_mac_address(coordinator.macAddress())
+    if normalized_mac is not None:
+        dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, coordinator.macAddress())},
+            connections={(CONNECTION_NETWORK_MAC, normalized_mac)},
+            manufacturer=MANUFACTURER,
+            configuration_url=f"http://{host}",
+            model=MODEL,
+            name=DEFAULT_NAME,
+            hw_version=coordinator.firmwareVersion(),
+            sw_version=coordinator.firmwareVersion(),
+        )
+        if entry.unique_id != normalized_mac:
+            hass.config_entries.async_update_entry(entry, unique_id=normalized_mac)
+
     _async_update_outlet_entity_names(hass, entry, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -103,7 +128,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate older config entries and entity IDs."""
-    if entry.version > 2:
+    if entry.version > 3:
         _LOGGER.error("Unsupported config entry version %s", entry.version)
         return False
 
@@ -130,6 +155,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
 
         hass.config_entries.async_update_entry(entry, version=2)
+
+    if entry.version == 2:
+        hass.config_entries.async_update_entry(entry, version=3)
 
     return True
 

--- a/custom_components/kohler/config_flow.py
+++ b/custom_components/kohler/config_flow.py
@@ -34,7 +34,11 @@ class KohlerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors: dict[str, str] = {}
-        default_host = self._discovered_host or ""
+        default_host = (
+            user_input.get(CONF_HOST)
+            if user_input is not None
+            else self._discovered_host or ""
+        )
 
         if user_input is not None:
             host = user_input[CONF_HOST]

--- a/custom_components/kohler/config_flow.py
+++ b/custom_components/kohler/config_flow.py
@@ -12,10 +12,12 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from kohler import Kohler, KohlerError
 
 from .const import CONF_ACCEPT_LIABILITY_TERMS, DOMAIN
+from .entity_helpers import normalize_mac_address
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -23,25 +25,37 @@ _LOGGER = logging.getLogger(__package__)
 class KohlerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Kohler config flow."""
 
-    VERSION = 2
+    VERSION = 3
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovered_host: str | None = None
 
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors: dict[str, str] = {}
+        default_host = self._discovered_host or ""
 
         if user_input is not None:
+            host = user_input[CONF_HOST]
+            self._async_abort_entries_match({CONF_HOST: host})
+
             if not user_input[CONF_ACCEPT_LIABILITY_TERMS]:
                 errors[CONF_ACCEPT_LIABILITY_TERMS] = "accept_terms"
-            elif not await self.test_connection(user_input[CONF_HOST]):
-                errors[CONF_HOST] = "cannot_connect"
             else:
-                return self.async_create_entry(
-                    title=user_input[CONF_HOST], data=user_input
-                )
+                unique_id = await self.test_connection(host)
+                if unique_id is None:
+                    errors[CONF_HOST] = "cannot_connect"
+                else:
+                    await self.async_set_unique_id(unique_id, raise_on_progress=False)
+                    self._abort_if_unique_id_configured(
+                        updates=user_input,
+                        reload_on_update=True,
+                    )
+                    return self.async_create_entry(title=host, data=user_input)
 
-        # Validation of the user's configuration
         data_schema = {
-            vol.Required(CONF_HOST): cv.string,
+            vol.Required(CONF_HOST, default=default_host): cv.string,
             vol.Required(CONF_ACCEPT_LIABILITY_TERMS): cv.boolean,
         }
 
@@ -50,6 +64,26 @@ class KohlerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(data_schema),
             errors=errors,
         )
+
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> FlowResult:
+        """Handle a flow initialized by DHCP discovery."""
+        host = discovery_info.ip
+        discovered_mac = normalize_mac_address(discovery_info.macaddress)
+
+        self._async_abort_entries_match({CONF_HOST: host})
+
+        if discovered_mac is not None:
+            await self.async_set_unique_id(discovered_mac, raise_on_progress=False)
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: host},
+                reload_on_update=True,
+            )
+
+        if await self.test_connection(host) is None:
+            return self.async_abort(reason="cannot_connect")
+
+        self._discovered_host = host
+        return await self.async_step_user()
 
     async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
         """Import a config entry."""
@@ -60,13 +94,13 @@ class KohlerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         }
         return await self.async_step_user(user_input)
 
-    async def test_connection(self, host: str) -> bool:
-        """Test connection to the Kohler device."""
+    async def test_connection(self, host: str) -> str | None:
+        """Test connection to the Kohler device and return its MAC address."""
         try:
             api = Kohler(kohler_host=host, timeout=5.0)
             async with asyncio.timeout(10.0):
-                await api.values()
-            return True
+                values = await api.values()
+            return normalize_mac_address(values.get("MAC"))
         except (KohlerError, OSError, asyncio.TimeoutError) as ex:
             _LOGGER.error("Error connecting to Kohler DTV+ %s", ex)
-            return False
+            return None

--- a/custom_components/kohler/coordinator.py
+++ b/custom_components/kohler/coordinator.py
@@ -104,6 +104,7 @@ class KohlerDataUpdateCoordinator(DataUpdateCoordinator):
             async with self._api_lock:
                 async with asyncio.timeout(10):
                     self._values = await self.api.values()
+                async with asyncio.timeout(10):
                     self._sysInfo = await self.api.system_info()
                 self._mapOutlets()
                 self._sync_selected_outlet_state()

--- a/custom_components/kohler/entity_helpers.py
+++ b/custom_components/kohler/entity_helpers.py
@@ -358,3 +358,17 @@ def _translate_option(value: object, options: dict[int, str]) -> str | None:
     if key is None:
         return None
     return options.get(key, str(value))
+
+
+def normalize_mac_address(value: object) -> str | None:
+    """Normalize a MAC address for config-entry and device-registry use."""
+    if not isinstance(value, str):
+        return None
+
+    cleaned = value.strip().lower().replace("-", "").replace(":", "")
+    if len(cleaned) != 12:
+        return None
+    if any(char not in "0123456789abcdef" for char in cleaned):
+        return None
+
+    return ":".join(cleaned[index : index + 2] for index in range(0, 12, 2))

--- a/custom_components/kohler/manifest.json
+++ b/custom_components/kohler/manifest.json
@@ -15,6 +15,6 @@
     "documentation": "https://github.com/niemyjski/homeassistant-kohler",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/niemyjski/homeassistant-kohler/issues",
-    "requirements": ["kohler>=0.1.0"],
+    "requirements": ["kohler>=0.1.1"],
     "version": "0.5.1"
 }

--- a/custom_components/kohler/manifest.json
+++ b/custom_components/kohler/manifest.json
@@ -4,9 +4,18 @@
     "codeowners": ["@niemyjski"],
     "config_flow": true,
     "dependencies": ["http"],
+    "dhcp": [
+        {
+            "macaddress": "00146F*"
+        },
+        {
+            "macaddress": "E845EB*"
+        }
+    ],
     "documentation": "https://github.com/niemyjski/homeassistant-kohler",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/niemyjski/homeassistant-kohler/issues",
+    "registered_devices": true,
     "requirements": ["kohler>=0.1.0"],
-    "version": "0.5.0"
+    "version": "0.5.1"
 }

--- a/custom_components/kohler/manifest.json
+++ b/custom_components/kohler/manifest.json
@@ -15,7 +15,6 @@
     "documentation": "https://github.com/niemyjski/homeassistant-kohler",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/niemyjski/homeassistant-kohler/issues",
-    "registered_devices": true,
     "requirements": ["kohler>=0.1.0"],
     "version": "0.5.1"
 }

--- a/custom_components/kohler/strings.json
+++ b/custom_components/kohler/strings.json
@@ -12,6 +12,10 @@
         "error": {
             "accept_terms": "You must accept the Liability Terms",
             "cannot_connect": "Cannot connect to the specified address or it is not a Kohler DTV+"
+        },
+        "abort": {
+            "already_configured": "This Kohler device is already configured",
+            "cannot_connect": "Cannot connect to the discovered Kohler device"
         }
     }
 }

--- a/custom_components/kohler/translations/en.json
+++ b/custom_components/kohler/translations/en.json
@@ -12,6 +12,10 @@
         "error": {
             "accept_terms": "You must accept the Liability Terms",
             "cannot_connect": "Cannot connect to the specified address or it is not a Kohler DTV+"
+        },
+        "abort": {
+            "already_configured": "This Kohler device is already configured",
+            "cannot_connect": "Cannot connect to the discovered Kohler device"
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kohler-ha"
-version = "0.5.0"
+version = "0.5.1"
 description = "Home Assistant Kohler Integration"
 authors = [{name = "Blake Niemyjski"}]
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Home Assistant Kohler Integration"
 authors = [{name = "Blake Niemyjski"}]
 requires-python = ">=3.14"
 dependencies = [
-    "kohler>=0.1.0",
+    "kohler>=0.1.1",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,4 +6,4 @@ coverage
 ruff
 mypy
 homeassistant
-kohler>=0.1.0
+kohler>=0.1.1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -66,6 +66,12 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {CONF_HOST: "cannot_connect"}
+    host_key = next(
+        key
+        for key in result2["data_schema"].schema
+        if getattr(key, "schema", None) == CONF_HOST
+    )
+    assert host_key.default() == "1.1.1.1"
 
 
 async def test_dhcp_discovery_prefills_user_form(hass):
@@ -109,15 +115,19 @@ async def test_dhcp_updates_existing_entry_by_unique_id(hass):
     )
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
-        data=DhcpServiceInfo(
-            ip="192.0.2.30",
-            hostname="kohler-controller",
-            macaddress="001122334455",
-        ),
-    )
+    with patch(
+        "custom_components.kohler.config_flow.KohlerFlowHandler.test_connection",
+        new=AsyncMock(return_value="00:11:22:33:44:55"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
+                ip="192.0.2.30",
+                hostname="kohler-controller",
+                macaddress="001122334455",
+            ),
+        )
 
     await hass.async_block_till_done()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_HOST
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.kohler.const import DOMAIN, CONF_ACCEPT_LIABILITY_TERMS
 
@@ -19,7 +21,7 @@ async def test_form_valid(hass):
     with (
         patch(
             "custom_components.kohler.config_flow.KohlerFlowHandler.test_connection",
-            new=AsyncMock(return_value=True),
+            new=AsyncMock(return_value="00:11:22:33:44:55"),
         ),
         patch(
             "custom_components.kohler.async_setup_entry",
@@ -52,7 +54,7 @@ async def test_form_cannot_connect(hass):
 
     with patch(
         "custom_components.kohler.config_flow.KohlerFlowHandler.test_connection",
-        new=AsyncMock(return_value=False),
+        new=AsyncMock(return_value=None),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -64,3 +66,61 @@ async def test_form_cannot_connect(hass):
 
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {CONF_HOST: "cannot_connect"}
+
+
+async def test_dhcp_discovery_prefills_user_form(hass):
+    """DHCP discovery should route into the setup form with the host prefilled."""
+    with patch(
+        "custom_components.kohler.config_flow.KohlerFlowHandler.test_connection",
+        new=AsyncMock(return_value="00:11:22:33:44:55"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
+                ip="192.0.2.20",
+                hostname="kohler-controller",
+                macaddress="001122334455",
+            ),
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+    host_key = next(
+        key
+        for key in result["data_schema"].schema
+        if getattr(key, "schema", None) == CONF_HOST
+    )
+    assert host_key.default() == "192.0.2.20"
+
+
+async def test_dhcp_updates_existing_entry_by_unique_id(hass):
+    """DHCP discovery should update the host for an existing configured device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Kohler",
+        data={
+            CONF_HOST: "192.0.2.10",
+            CONF_ACCEPT_LIABILITY_TERMS: True,
+        },
+        unique_id="00:11:22:33:44:55",
+        version=3,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="192.0.2.30",
+            hostname="kohler-controller",
+            macaddress="001122334455",
+        ),
+    )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == "192.0.2.30"

--- a/tests/test_entity_helpers.py
+++ b/tests/test_entity_helpers.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from custom_components.kohler.entity_helpers import (
     build_outlet_descriptors,
     format_kohler_datetime,
+    normalize_mac_address,
     translate_auto_purge_setting,
     translate_cold_water_setting,
     translate_connection_status,
@@ -108,3 +109,18 @@ def test_translate_controller_settings_to_ui_labels():
     assert translate_max_run_time_setting(2, False) == "Off"
     assert translate_connection_status("con") == "Connected"
     assert translate_connection_status("intermittent") == "Intermittent"
+
+
+def test_normalize_mac_address_accepts_supported_formats():
+    """MAC addresses should normalize across the common formats we encounter."""
+    assert normalize_mac_address("00:11:22:33:44:55") == "00:11:22:33:44:55"
+    assert normalize_mac_address("00-11-22-33-44-55") == "00:11:22:33:44:55"
+    assert normalize_mac_address("001122334455") == "00:11:22:33:44:55"
+    assert normalize_mac_address("AA-bb-CC-dd-EE-ff") == "aa:bb:cc:dd:ee:ff"
+
+
+def test_normalize_mac_address_rejects_invalid_values():
+    """Invalid MAC address values should be rejected cleanly."""
+    assert normalize_mac_address("00:11:22:33:44") is None
+    assert normalize_mac_address("00:11:22:33:44:gg") is None
+    assert normalize_mac_address(12345) is None

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.14"
 
 [[package]]
 name = "kohler"
-version = "0.1.0"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/aa/5059bdd3c42ff3c9f25329c64b80a151edd9080a7f49c1e0bc32981234b4/kohler-0.1.0.tar.gz", hash = "sha256:08c01e38974aa5a0e943298aabcab33ae54967e0711b226dd1c6e61d602b4f6a", size = 12994, upload-time = "2026-03-19T00:15:35.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/22/757eaf9700dacbb981def15fae3fb07302481500081214806dbca4a35544/kohler-0.1.1.tar.gz", hash = "sha256:5b8946225c4a11cc7ed8b92c911dbffccd3eddbef1a3b57e9e4f21bee5dbb039", size = 15152, upload-time = "2026-03-19T17:54:40.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/8d/fd23af6aa9928996cd0457bf402b1123e6086f90447125e367d57ff37820/kohler-0.1.0-py3-none-any.whl", hash = "sha256:29368c256c5eb7d865871c177ac5b96562516f2c5f7f740c5a44d99541b18217", size = 10433, upload-time = "2026-03-19T00:15:34.194Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ba/760094d9ed564ee6943bc81664f5ee6dd4f3b5e72f1828d00f349e1a9495/kohler-0.1.1-py3-none-any.whl", hash = "sha256:3831081f8a41c0155fe0101725666240b6985b8eebfa2b0d0179017495f570ca", size = 11747, upload-time = "2026-03-19T17:54:38.541Z" },
 ]
 
 [[package]]
@@ -20,4 +20,4 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "kohler", specifier = ">=0.1.0" }]
+requires-dist = [{ name = "kohler", specifier = ">=0.1.1" }]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "kohler-ha"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "kohler" },


### PR DESCRIPTION
## Summary
- add DHCP autodiscovery using known Kohler MAC prefixes
- use MAC-based unique IDs and device registry connections so rediscovery can update the stored host
- bump the integration version to 0.5.1 and cover the new flow with tests

## Testing
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/pytest

Fixes #10