### PR TITLE
Consider PurgeActive as valve on

### DIFF
--- a/custom_components/kohler/coordinator.py
+++ b/custom_components/kohler/coordinator.py
@@ -441,7 +441,8 @@ class KohlerDataUpdateCoordinator(DataUpdateCoordinator):
         return self.getSystemInfo(f"valve{valve}outlet{mapped_outlet}", False)
 
     def isValveOn(self, valve: int) -> bool:
-        return self.getSystemInfo(f"valve{valve}_Currentstatus", "Off") == "On"
+        status = self.getSystemInfo(f"valve{valve}_Currentstatus", "Off")
+        return status in ("On", "PurgeActive")
 
     def getDeviceTime(self) -> str | None:
         """Return the configured device time string."""


### PR DESCRIPTION
Add support for the PurgeActive state to recognize the shower as on. This state occurs if the shower is configured to have a startup purge to remove cold water.